### PR TITLE
При импорте товара не добавлять товар с существующим кодом.

### DIFF
--- a/src/main/lsfusion/masterdata/items/products/ProductImport.lsf
+++ b/src/main/lsfusion/masterdata/items/products/ProductImport.lsf
@@ -60,8 +60,11 @@ productImport 'Импорт товаров' () {
                 RETURN;
             }  
             
-            FOR imported(INTEGER i) DO NEW p = Product {
+            FOR id(INTEGER i) AND NOT item(id(i)) DO NEW p = Product {
                 id(p) <- id(i);
+            }
+            
+            FOR id(Product p) = id(INTEGER i) DO {
                 dataName(p) <- name(i);
                 category(p) <- category(idCategory(i));
                 uom(p) <- uom(idUom(i));


### PR DESCRIPTION
При импорте товаров вместо попытки добавления товара с существующим кодом, его поля перезаписываются значениями из файла импорта. ( closes #234  )